### PR TITLE
Add a timeout option for healtcheck Handler

### DIFF
--- a/checkers/diskspace.go
+++ b/checkers/diskspace.go
@@ -1,6 +1,7 @@
 package checkers
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"syscall"
@@ -15,7 +16,7 @@ type diskspace struct {
 }
 
 //Check test if the filesystem disk usage is above threshold
-func (ds *diskspace) Check() error {
+func (ds *diskspace) Check(ctx context.Context) error {
 	if _, err := os.Stat(ds.dir); err != nil {
 		return fmt.Errorf("filesystem not found: %v", err)
 	}

--- a/checkers/heartbeat.go
+++ b/checkers/heartbeat.go
@@ -1,6 +1,7 @@
 package checkers
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -13,7 +14,7 @@ type heartbeat struct {
 	path string
 }
 
-func (h *heartbeat) Check() error {
+func (h *heartbeat) Check(ctx context.Context) error {
 	if _, err := os.Stat(h.path); err != nil {
 		return errors.New("heartbeat not found. application should be out of rotation")
 	}

--- a/health.go
+++ b/health.go
@@ -1,15 +1,19 @@
 package healthcheck
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"sync"
+	"time"
 )
 
 type (
 	health struct {
 		checkers  map[string]Checker
 		observers map[string]Checker
+		timeout   time.Duration
 	}
 
 	response struct {
@@ -23,11 +27,11 @@ type (
 	// Checker checks the status of the dependency and returns error.
 	// In case the dependency is working as expected, return nil.
 	Checker interface {
-		Check() error
+		Check(ctx context.Context) error
 	}
 
 	// CheckerFunc is a convenience type to create functions that implement the Checker interface. Shoutout to https://github.com/docker/go-healthcheck for this tip :)
-	CheckerFunc func() error
+	CheckerFunc func(ctx context.Context) error
 )
 
 // Handler returns an http.Handler
@@ -50,34 +54,50 @@ func HandlerFunc(opts ...Option) http.HandlerFunc {
 
 // Check Implements the Checker interface to allow for any func() error method
 // to be passed as a Checker
-func (c CheckerFunc) Check() error {
-	return c()
+func (c CheckerFunc) Check(ctx context.Context) error {
+	return c(ctx)
 }
 
 // WithChecker adds a status checker that needs to be added as part of healthcheck. i.e database, cache or any external dependency
 func WithChecker(name string, s Checker) Option {
 	return func(h *health) {
-		h.checkers[name] = s
+		h.checkers[name] = &timeoutChecker{s}
 	}
 }
 
 // WithObserver adds a status checker but it does not fail the whole status
 func WithObserver(name string, s Checker) Option {
 	return func(h *health) {
-		h.observers[name] = s
+		h.observers[name] = &timeoutChecker{s}
+	}
+}
+
+// WithTimeout configures the global timeout for individual checkers
+func WithTimeout(timeout time.Duration) Option {
+	return func(h *health) {
+		h.timeout = timeout
 	}
 }
 
 func (h *health) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	nCheckers := len(h.checkers) + len(h.observers)
+
 	code := http.StatusOK
-	errorMsgs := make(map[string]string)
+	errorMsgs := make(map[string]string, nCheckers)
+
+	ctx, cancel := context.Background(), func() {}
+	if h.timeout != 0 {
+		ctx, cancel = context.WithTimeout(ctx, h.timeout)
+	}
+	defer cancel()
+
 	var mutex sync.Mutex
 	var wg sync.WaitGroup
-	wg.Add(len(h.checkers) + len(h.observers))
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	wg.Add(nCheckers)
+
 	for key, checker := range h.checkers {
 		go func(key string, checker Checker) {
-			if err := checker.Check(); err != nil {
+			if err := checker.Check(ctx); err != nil {
 				mutex.Lock()
 				errorMsgs[key] = err.Error()
 				code = http.StatusServiceUnavailable
@@ -87,8 +107,8 @@ func (h *health) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}(key, checker)
 	}
 	for key, observer := range h.observers {
-		go func(key string, checker Checker) {
-			if err := observer.Check(); err != nil {
+		go func(key string, observer Checker) {
+			if err := observer.Check(ctx); err != nil {
 				mutex.Lock()
 				errorMsgs[key] = err.Error()
 				mutex.Unlock()
@@ -96,10 +116,30 @@ func (h *health) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			wg.Done()
 		}(key, observer)
 	}
+
 	wg.Wait()
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(code)
 	json.NewEncoder(w).Encode(response{
 		Status: http.StatusText(code),
 		Errors: errorMsgs,
 	})
+}
+
+type timeoutChecker struct {
+	checker Checker
+}
+
+func (t *timeoutChecker) Check(ctx context.Context) error {
+	checkerChan := make(chan error)
+	go func() {
+		checkerChan <- t.checker.Check(ctx)
+	}()
+	select {
+	case err := <-checkerChan:
+		return err
+	case <-ctx.Done():
+		return errors.New("max check time exceeded")
+	}
 }


### PR DESCRIPTION
Fixes #5
If we decide to export the private timeoutChecker introduced here, It could also solve checker specific timeouts. All one has to do is to wrap an existing timer with a timeout checker.