### PR TITLE
fix; readme with example for v2.0.0 

### DIFF
--- a/checkers/diskspace.go
+++ b/checkers/diskspace.go
@@ -29,14 +29,14 @@ func (ds *diskspace) Check(ctx context.Context) error {
 	total := fs.Blocks * uint64(fs.Bsize)
 	free := fs.Bfree * uint64(fs.Bsize)
 	used := total - free
-
-	if 100*used/total > ds.threshold {
-		return fmt.Errorf("space used on %s greater than threshold %d%%(%d%%)", ds.dir, ds.threshold, 100*used/total)
+	usedPercentage := 100 * used / total
+	if usedPercentage > ds.threshold {
+		return fmt.Errorf("used: %d%% threshold: %d%% location: %s", usedPercentage, ds.threshold, ds.dir)
 	}
 	return nil
 }
 
-// DiskSpace returns a diskspace health checker, which checks if filesystem usage is above threshold
+// DiskSpace returns a diskspace health checker, which checks if filesystem usage is above the threshold which is defined in percentage.
 func DiskSpace(dir string, threshold uint64) healthcheck.Checker {
 	return &diskspace{
 		dir:       dir,

--- a/health.go
+++ b/health.go
@@ -30,7 +30,7 @@ type (
 		Check(ctx context.Context) error
 	}
 
-	// CheckerFunc is a convenience type to create functions that implement the Checker interface. Shoutout to https://github.com/docker/go-healthcheck for this tip :)
+	// CheckerFunc is a convenience type to create functions that implement the Checker interface.
 	CheckerFunc func(ctx context.Context) error
 )
 
@@ -65,14 +65,14 @@ func WithChecker(name string, s Checker) Option {
 	}
 }
 
-// WithObserver adds a status checker but it does not fail the whole status
+// WithObserver adds a status checker but it does not fail the entire status.
 func WithObserver(name string, s Checker) Option {
 	return func(h *health) {
 		h.observers[name] = &timeoutChecker{s}
 	}
 }
 
-// WithTimeout configures the global timeout for individual checkers
+// WithTimeout configures the global timeout for all individual checkers.
 func WithTimeout(timeout time.Duration) Option {
 	return func(h *health) {
 		h.timeout = timeout


### PR DESCRIPTION
- fix; missing context as argument to the `checkerfunc` in the readme example.
- cleanup; diskspace checker error format
- cleanup; minor documentation