### PR TITLE
Set default timeout to 30s

### DIFF
--- a/health.go
+++ b/health.go
@@ -9,30 +9,26 @@ import (
 	"time"
 )
 
-type (
-	health struct {
-		checkers  map[string]Checker
-		observers map[string]Checker
-		timeout   time.Duration
-	}
+type health struct {
+	checkers  map[string]Checker
+	observers map[string]Checker
+	timeout   time.Duration
+}
 
-	response struct {
-		Status string            `json:"status,omitempty"`
-		Errors map[string]string `json:"errors,omitempty"`
-	}
+// Checker checks the status of the dependency and returns error.
+// In case the dependency is working as expected, return nil.
+type Checker interface {
+	Check(ctx context.Context) error
+}
 
-	// Option adds optional parameter for the HealthcheckHandlerFunc
-	Option func(*health)
+// CheckerFunc is a convenience type to create functions that implement the Checker interface.
+type CheckerFunc func(ctx context.Context) error
 
-	// Checker checks the status of the dependency and returns error.
-	// In case the dependency is working as expected, return nil.
-	Checker interface {
-		Check(ctx context.Context) error
-	}
-
-	// CheckerFunc is a convenience type to create functions that implement the Checker interface.
-	CheckerFunc func(ctx context.Context) error
-)
+// Check Implements the Checker interface to allow for any func() error method
+// to be passed as a Checker
+func (c CheckerFunc) Check(ctx context.Context) error {
+	return c(ctx)
+}
 
 // Handler returns an http.Handler
 func Handler(opts ...Option) http.Handler {
@@ -41,7 +37,6 @@ func Handler(opts ...Option) http.Handler {
 		observers: make(map[string]Checker),
 		timeout:   30 * time.Second,
 	}
-
 	for _, opt := range opts {
 		opt(h)
 	}
@@ -53,11 +48,8 @@ func HandlerFunc(opts ...Option) http.HandlerFunc {
 	return Handler(opts...).ServeHTTP
 }
 
-// Check Implements the Checker interface to allow for any func() error method
-// to be passed as a Checker
-func (c CheckerFunc) Check(ctx context.Context) error {
-	return c(ctx)
-}
+// Option adds optional parameter for the HealthcheckHandlerFunc
+type Option func(*health)
 
 // WithChecker adds a status checker that needs to be added as part of healthcheck. i.e database, cache or any external dependency
 func WithChecker(name string, s Checker) Option {
@@ -122,10 +114,15 @@ func (h *health) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(code)
-	json.NewEncoder(w).Encode(response{
-		Status: http.StatusText(code),
-		Errors: errorMsgs,
-	})
+	json.NewEncoder(w).Encode(
+		struct {
+			Status string            `json:"status,omitempty"`
+			Errors map[string]string `json:"errors,omitempty"`
+		}{
+			Status: http.StatusText(code),
+			Errors: errorMsgs,
+		},
+	)
 }
 
 type timeoutChecker struct {

--- a/health.go
+++ b/health.go
@@ -39,6 +39,7 @@ func Handler(opts ...Option) http.Handler {
 	h := &health{
 		checkers:  make(map[string]Checker),
 		observers: make(map[string]Checker),
+		timeout:   30 * time.Second,
 	}
 
 	for _, opt := range opts {

--- a/health.go
+++ b/health.go
@@ -9,6 +9,11 @@ import (
 	"time"
 )
 
+type response struct {
+	Status string            `json:"status,omitempty"`
+	Errors map[string]string `json:"errors,omitempty"`
+}
+
 type health struct {
 	checkers  map[string]Checker
 	observers map[string]Checker
@@ -114,15 +119,10 @@ func (h *health) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(code)
-	json.NewEncoder(w).Encode(
-		struct {
-			Status string            `json:"status,omitempty"`
-			Errors map[string]string `json:"errors,omitempty"`
-		}{
-			Status: http.StatusText(code),
-			Errors: errorMsgs,
-		},
-	)
+	json.NewEncoder(w).Encode(response{
+		Status: http.StatusText(code),
+		Errors: errorMsgs,
+	})
 }
 
 type timeoutChecker struct {


### PR DESCRIPTION
It's better to set a safe timeout default rather than use the default value of 0. 30s might be too high for most health checks, and it has to be specific for every application.